### PR TITLE
视频投稿时，将默认最大只能10MB调整到50MB

### DIFF
--- a/BaseInterface/etc/BaseInterface-Api.yaml
+++ b/BaseInterface/etc/BaseInterface-Api.yaml
@@ -1,4 +1,4 @@
 Name: BaseInterface-api
 Host: 0.0.0.0
 Port: 8888
-MaxBytes: 10485760
+MaxBytes: 52428800


### PR DESCRIPTION
视频投稿时，将默认最大只能10MB调整到50MB