### PR TITLE
fix:解决app中无法正确读取视频播放链接的问题

### DIFF
--- a/external_api/api/commondatastructure.api
+++ b/external_api/api/commondatastructure.api
@@ -11,14 +11,13 @@ type Video {
 }
 
 type VideoTest {
-	Id            int64  `form:"id"`
-	Author        User   `form:"author"`
-	PlayUrl       string `form:"play_url"`
-	CoverUrl      string `form:"cover_url"`
-	FavoriteCount int64  `form:"favorite_count"`
-	CommentCount  int64  `form:"comment_count"`
-	IsFavotite    bool   `form:"is_favorite"`
-	// VideoTitle    string `form:"video_title"`
+		Id            int64  `form:"id" json:"id"`
+	Author        User   `form:"author" json:"author"`
+	PlayUrl       string `form:"play_url" json:"play_url"`
+	CoverUrl      string `form:"cover_url" json:"cover_url"`
+	FavoriteCount int64  `form:"favorite_count" json:"favorite_count"`
+	CommentCount  int64  `form:"comment_count" json:"comment_count"`
+	IsFavotite    bool   `form:"is_favorite" json:"is_favorite"`
 }
 
 

--- a/external_api/baseinterface/internal/logic/BaseInterface/feedlogic.go
+++ b/external_api/baseinterface/internal/logic/BaseInterface/feedlogic.go
@@ -108,11 +108,11 @@ func (l *FeedLogic) Feed(req *types.FeedHandlerRequest) (resp *types.FeedHandler
 		respFeedVideoList[index].Id = 1
 		respFeedVideoList[index].Author = respFeedUserInfo
 		// respFeedVideoList[index].PlayUrl = "175.178.93.55:9001/test-minio/vidoeFile/790ae4b3-cce7-43fe-bfd6-8ee82a23ca74-video_test6.mp4"
-		respFeedVideoList[index].PlayUrl = "https://www.w3schools.com/html/movie.mp4"
+		respFeedVideoList[index].PlayUrl = "http://175.178.93.55:9001/test-minio/vidoeFile/94e010c6-4c6e-4c2c-8d0b-b9afea9760d6-video_test12.mp4"
 		// respFeedVideoList[index].PlayUrl = getFileExtFromImageUrl(val.PlayUrl)
 		// keyval, _ := DecodeFileKey(val.CoverUrl)
 		// respFeedVideoList[index].CoverUrl = val.CoverUrl
-		respFeedVideoList[index].CoverUrl = "https://cdn.pixabay.com/photo/2016/03/27/18/10/bear-1283347_1280.jpg"
+		respFeedVideoList[index].CoverUrl = "http://www.baidu.com/img/PCtm_d9c8750bed0b3c7d089fa7d55720d6cf.png"
 		respFeedVideoList[index].FavoriteCount = val.FavoriteCount
 		respFeedVideoList[index].CommentCount = val.CommentCount
 		respFeedVideoList[index].IsFavotite = val.IsFavotite

--- a/external_api/baseinterface/internal/logic/BaseInterface/publishactionlogic.go
+++ b/external_api/baseinterface/internal/logic/BaseInterface/publishactionlogic.go
@@ -77,7 +77,7 @@ func (l *PublishActionLogic) PublishAction(req *types.PublishActionHandlerReques
 		return nil, err
 	}
 	return &types.PublishActionHandlerResponse{
-		StatusCode: int32(commonerror.CommonErr_STATUS_OK),
+		StatusCode: 0,
 		StatusMsg:  "上传成功",
 	}, err
 }

--- a/external_api/baseinterface/internal/types/types.go
+++ b/external_api/baseinterface/internal/types/types.go
@@ -81,13 +81,13 @@ type Video struct {
 }
 
 type VideoTest struct {
-	Id            int64  `form:"id"`
-	Author        User   `form:"author"`
-	PlayUrl       string `form:"play_url"`
-	CoverUrl      string `form:"cover_url"`
-	FavoriteCount int64  `form:"favorite_count"`
-	CommentCount  int64  `form:"comment_count"`
-	IsFavotite    bool   `form:"is_favorite"`
+	Id            int64  `form:"id" json:"id"`
+	Author        User   `form:"author" json:"author"`
+	PlayUrl       string `form:"play_url" json:"play_url"`
+	CoverUrl      string `form:"cover_url" json:"cover_url"`
+	FavoriteCount int64  `form:"favorite_count" json:"favorite_count"`
+	CommentCount  int64  `form:"comment_count" json:"comment_count"`
+	IsFavotite    bool   `form:"is_favorite" json:"is_favorite"`
 }
 
 type User struct {


### PR DESCRIPTION
将接口 /douyin/feed 响应的json数据内的video_list的所有子key，首单词转为小写字母
json data example：
{
    "status_code": 0,
    "status_msg": "feed video success",
    "video_list": [
        {
            "id": 1,
            "author": {
                "id": 354,
                "name": "1231233",
                "follow_count": 0,
                "follower_count": 0,
                "is_follow": false
            },
            "play_url": "https://www.w3schools.com/html/movie.mp4",
            "cover_url": "https://cdn.pixabay.com/photo/2016/03/27/18/10/bear-1283347_1280.jpg",
            "favorite_count": 0,
            "comment_count": 0,
            "is_favorite": false
        }
    ],
    "next_time": 1675322047
}