### PR TITLE
fix: 修复nginx在转发端口时，转发用户上传的视频超过1MB报错的bug

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -26,6 +26,7 @@ server {
     listen  [::]:4444;
     server_name  localhost; #服务器域名
 
+    client_max_body_size 1024m;
     # 证书公钥
     #ssl_certificate /root/cert/fullchain.crt;
     # 证书私钥
@@ -53,7 +54,7 @@ server {
     #ssl_stapling on;
     #ssl_stapling_verify on;
     
-    location ~/douyin/feed/ {
+    location ~/douyin/feed {
 		proxy_pass http://127.0.0.1:8888;
     }
     


### PR DESCRIPTION
fix:修复nginx在转发端口时，转发用户上传的视频超过1MB报错的bug