### PR TITLE
feat: 增加redis，将follow_and_follower_list改造成redis，这个表弃用

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "./external_api/baseinterface/baseinterface.go",
-            "args": ["-f","${workspaceFolder}/bin/etc/external_api/baseinterface.yaml"],
+            "program": "./external_api/relationfollow/relationfollowinterface.go",
+            "args": ["-f","${workspaceFolder}/bin/etc/external_api/relationfollowinterface.yaml"],
             "env":{}
         }
     ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,32 @@ nginx配置文件即文件目录下的default.conf（nginx默认配置）
 这里具体每个参数的值设为多少最好待调试
 
 
+# redis相关
+
+```shell
+sudo apt-get update 
+sudo apt-get install redis # 安装
+redis-server -v # 查看redis版本
+redis-cli # 登录redis
+```
+```shell
+set 123 test
+get 123 
+del 123
+ping
+
+keys * # 查一下有什么键
+
+SMEMBERS FollowAndFollowerList:follower_id:323    # 我们的数据类型是set，查询一下关注列表
+SMEMBERS FollowAndFollowerList:user_id:1    # 查询一下粉丝列表
+
+# 获取set值
+smembers follower_id:300
+# 删除当前数据库中的所有Key
+flushdb
+# 删除所有数据库中的key
+flushall
+```
 # commit类型
 用于说明 commit 的类别，只允许使用下面7个标识。
 feat：新功能（feature）</br>
@@ -89,7 +115,8 @@ merge：代码合并 </br>
 sync：同步主线或分支的Bug </br>
 
 # 参考资料
-
-https://go-zero.dev/cn/docs/quick-start/monolithic-service
-https://go-zero.dev/cn/docs/goctl/goctl/
-https://go-zero.dev/cn/docs/goctl/goctl/
+[Goctl 简介]https://go-zero.dev/cn/docs/goctl/goctl/
+[go-redis]https://redis.uptrace.dev/zh/guide/
+[使用redis实现关注和粉丝列表 ｜ 青训营笔记]https://juejin.cn/post/7103869225260810277
+[go-redis文档]https://juejin.cn/post/7027347979065360392#heading-20
+[redis的五种数据结构和应用场景【如微博微信点赞/共同关注/加购物车】]https://juejin.cn/post/6895185457110319118#heading-21

--- a/external_api/relationfollow/relationfollowinterface.go
+++ b/external_api/relationfollow/relationfollowinterface.go
@@ -12,6 +12,8 @@ import (
 	"github.com/zeromicro/go-zero/rest"
 )
 
+
+
 var configFile = flag.String("f", "etc/relationfollowinterface.yaml", "the config file")
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-redis/redis v6.15.9+incompatible // indirect
 	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNI
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
 github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=

--- a/internal_proto/microservices/mysqlmanage/internal/logic/relationactionlogic.go
+++ b/internal_proto/microservices/mysqlmanage/internal/logic/relationactionlogic.go
@@ -31,17 +31,17 @@ type follow_and_follower_list struct {
 	FollowerId int64     `gorm:"cloumn:follower_id;"`
 	RecordTime time.Time `gorm:"cloumn:record_time;"`
 }
-
+ 
 // 关注、取消关注
 func (l *RelationActionLogic) RelationAction(in *mysqlmanageserver.RelationActionRequest) (*mysqlmanageserver.RelationActionResponse, error) {
 	// todo: add your logic here and delete this line
 	db := svc.DB
 	if in.ActionType == 1 { //关注
 		//#关注账号 user_id：被关注的账号  follower_id：哪个账号要关注
-		insertData := follow_and_follower_list{UserID: in.ToUserID, FollowerId: in.UserID, RecordTime: time.Now()}
-		if err := db.Table("follow_and_follower_list").Create(&insertData).Error; err != nil {
-			return &mysqlmanageserver.RelationActionResponse{Ok: false}, err
-		}
+		// insertData := follow_and_follower_list{UserID: in.ToUserID, FollowerId: in.UserID, RecordTime: time.Now()}
+		// if err := db.Table("follow_and_follower_list").Create(&insertData).Error; err != nil {
+		// 	return &mysqlmanageserver.RelationActionResponse{Ok: false}, err
+		// }
 		if err := db.Table("user_info").Where("user_id = ?", in.ToUserID).Update("follower_count", gorm.Expr("follower_count + ?", 1)).Error; err != nil {
 			return &mysqlmanageserver.RelationActionResponse{Ok: false}, nil
 		}
@@ -52,9 +52,9 @@ func (l *RelationActionLogic) RelationAction(in *mysqlmanageserver.RelationActio
 	} else if in.ActionType == 2 { //取消关注
 		//取消关注.  user_id：要被取消关注的账号   follower_id：哪个账号要取消关注
 
-		if err := db.Table("follow_and_follower_list").Where("user_id = ? and follower_id = ?", in.ToUserID, in.UserID).Delete(nil).Error; err != nil {
-			return &mysqlmanageserver.RelationActionResponse{Ok: false}, err
-		}
+		// if err := db.Table("follow_and_follower_list").Where("user_id = ? and follower_id = ?", in.ToUserID, in.UserID).Delete(nil).Error; err != nil {
+		// 	return &mysqlmanageserver.RelationActionResponse{Ok: false}, err
+		// }
 		if err := db.Table("user_info").Where("user_id = ?", in.ToUserID).Update("follower_count", gorm.Expr("follower_count - ?", 1)).Error; err != nil {
 			return &mysqlmanageserver.RelationActionResponse{Ok: false}, nil
 		}

--- a/internal_proto/microservices/mysqlmanage/internal/logic/relationfollowerlistlogic.go
+++ b/internal_proto/microservices/mysqlmanage/internal/logic/relationfollowerlistlogic.go
@@ -6,6 +6,7 @@ import (
 
 	"SimpleTikTok/internal_proto/microservices/mysqlmanage/internal/svc"
 	"SimpleTikTok/internal_proto/microservices/mysqlmanage/types/mysqlmanageserver"
+	"SimpleTikTok/oprations/redisconnect"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )
@@ -24,36 +25,76 @@ func NewRelationFollowerListLogic(ctx context.Context, svcCtx *svc.ServiceContex
 	}
 }
 
+const (
+	KVDBName = "FollowAndFollowerList:" //Redis-Set
+)
+
+type RelationUserInfo struct {
+	UserID        int64  // 用户ID
+	UserNickName  string // 用户名称
+	FollowCount   int64  // 关注总数
+	FollowerCount int64  // 粉丝总数
+	IsFollow      bool   // true-已关注
+}
+
 // 粉丝列表
 func (l *RelationFollowerListLogic) RelationFollowerList(in *mysqlmanageserver.RelationFollowerListRequest) (*mysqlmanageserver.RelationFollowerListResponse, error) {
-	// todo: add your logic here and delete this line
-
 	testUserList_ := make([]*mysqlmanageserver.RelationUser, 0)
 
-	db := svc.DB
-	//#查找某个账号的粉丝列表   user_id：账号
-	userInfoList, err := db.Raw(fmt.Sprintf("SELECT * FROM user_info where user_id in(SELECT follower_id FROM follow_and_follower_list where user_id=%d)", in.UserID)).Rows()
+	RedisDB, _ := redisconnect.RedisConnect()
+	followerIDString := fmt.Sprintf("%s%s:%d", KVDBName, "follower_id", in.UserID)
+	followerIDList, _ := RedisDB.SMembers(l.ctx, followerIDString).Result() // 找到粉丝的列表
 
-	if err != nil {
-		return &mysqlmanageserver.RelationFollowerListResponse{}, err
-	} else {
-		for userInfoList.Next() {
-			tempUserList := mysqlmanageserver.RelationUser{}
-			userInfoList.Scan(&tempUserList.Id, &tempUserList.Name, &tempUserList.FollowCount, &tempUserList.FollowerCount, &tempUserList.IsFollow) //！！err :查询出来的列数不同、数据格式不同时会报错，不影响格式正确的变量
-			testUserList_ = append(testUserList_, &tempUserList)
-		}
-		//查询一遍上面查出来的id，是否已被当前登录的账号关注
-		for i := 0; i < len(testUserList_); i++ {
+	for _, val := range followerIDList {
+		var userInfo RelationUserInfo
+		_ = svc.DB.Table("user_info").Where("user_id = ?", val).Find(&userInfo).Error
+		followerIDString := fmt.Sprintf("%s%s:%d", KVDBName, "follower_id", userInfo.UserID)
+		userInfoFollowCountList, _ := RedisDB.SMembers(l.ctx, followerIDString).Result() // 找到关注的列表
+		userIDString := fmt.Sprintf("%s%s:%d", KVDBName, "user_id", userInfo.UserID)
+		userInfoFollowerCountList, _ := RedisDB.SMembers(l.ctx, userIDString).Result() // 找到粉丝的列表
 
-			var ls CheckIsFollowLogic
-			isFollow := mysqlmanageserver.CheckIsFollowRequest{UserId: int64(testUserList_[i].Id), FollowerId: int64(in.LoginUserID)}
-			result, _ := ls.CheckIsFollow(&isFollow)
-			if result.Ok {
-				testUserList_[i].IsFollow = true
-			}
-		}
+		isFollowRedis := RedisDB.SIsMember(l.ctx, followerIDString, in.UserID).Val() // redis查看关注列表中是否有这个人
+		testUserList_ = append(testUserList_, &mysqlmanageserver.RelationUser{
+			Id:            userInfo.UserID,
+			Name:          userInfo.UserNickName,
+			FollowCount:   int64(len(userInfoFollowCountList)),
+			FollowerCount: int64(len(userInfoFollowerCountList)),
+			IsFollow:      isFollowRedis,
+		})
 	}
-	logx.Infof("\n\n%+v\n\n", &testUserList_)
 
 	return &mysqlmanageserver.RelationFollowerListResponse{RelationUser: testUserList_}, nil
 }
+
+// func (l *RelationFollowerListLogic) RelationFollowerList(in *mysqlmanageserver.RelationFollowerListRequest) (*mysqlmanageserver.RelationFollowerListResponse, error) {
+// 	// todo: add your logic here and delete this line
+
+// 	testUserList_ := make([]*mysqlmanageserver.RelationUser, 0)
+
+// 	db := svc.DB
+// 	//#查找某个账号的粉丝列表   user_id：账号
+// 	userInfoList, err := db.Raw(fmt.Sprintf("SELECT * FROM user_info where user_id in(SELECT follower_id FROM follow_and_follower_list where user_id=%d)", in.UserID)).Rows()
+
+// 	if err != nil {
+// 		return &mysqlmanageserver.RelationFollowerListResponse{}, err
+// 	} else {
+// 		for userInfoList.Next() {
+// 			tempUserList := mysqlmanageserver.RelationUser{}
+// 			userInfoList.Scan(&tempUserList.Id, &tempUserList.Name, &tempUserList.FollowCount, &tempUserList.FollowerCount, &tempUserList.IsFollow) //！！err :查询出来的列数不同、数据格式不同时会报错，不影响格式正确的变量
+// 			testUserList_ = append(testUserList_, &tempUserList)
+// 		}
+// 		//查询一遍上面查出来的id，是否已被当前登录的账号关注
+// 		for i := 0; i < len(testUserList_); i++ {
+
+// 			var ls CheckIsFollowLogic
+// 			isFollow := mysqlmanageserver.CheckIsFollowRequest{UserId: int64(testUserList_[i].Id), FollowerId: int64(in.LoginUserID)}
+// 			result, _ := ls.CheckIsFollow(&isFollow)
+// 			if result.Ok {
+// 				testUserList_[i].IsFollow = true
+// 			}
+// 		}
+// 	}
+// 	logx.Infof("\n\n%+v\n\n", &testUserList_)
+
+// 	return &mysqlmanageserver.RelationFollowerListResponse{RelationUser: testUserList_}, nil
+// }

--- a/internal_proto/microservices/mysqlmanage/internal/logic/relationfollowlistlogic.go
+++ b/internal_proto/microservices/mysqlmanage/internal/logic/relationfollowlistlogic.go
@@ -6,6 +6,7 @@ import (
 
 	"SimpleTikTok/internal_proto/microservices/mysqlmanage/internal/svc"
 	"SimpleTikTok/internal_proto/microservices/mysqlmanage/types/mysqlmanageserver"
+	"SimpleTikTok/oprations/redisconnect"
 
 	"github.com/zeromicro/go-zero/core/logx"
 )
@@ -26,30 +27,58 @@ func NewRelationFollowListLogic(ctx context.Context, svcCtx *svc.ServiceContext)
 
 // 关注列表
 func (l *RelationFollowListLogic) RelationFollowList(in *mysqlmanageserver.RelationFollowListRequest) (resp *mysqlmanageserver.RelationFollowListResponse, respErr error) {
-	// todo: add your logic here and delete this line
-
 	testUserList_ := make([]*mysqlmanageserver.RelationUser, 0)
 
-	db := svc.DB
-	//#查询某个账号关注的所有账号   follower_id：账号
-	userInfoList, err := db.Raw(fmt.Sprintf("SELECT * FROM user_info where user_id in(SELECT user_id FROM follow_and_follower_list where follower_id = %d)", in.UserID)).Rows()
-	if err != nil {
-		return &mysqlmanageserver.RelationFollowListResponse{}, err
-	} else {
-		for userInfoList.Next() {
-			tempUserList := mysqlmanageserver.RelationUser{}
-			userInfoList.Scan(&tempUserList.Id, &tempUserList.Name, &tempUserList.FollowCount, &tempUserList.FollowerCount, &tempUserList.IsFollow) //！！err :查询出来的列数不同、数据格式不同时会报错，不影响格式正确的变量
-			testUserList_ = append(testUserList_, &tempUserList)
-		}
-		//查询一遍上面查出来的id，是否已被当前登录的账号关注
-		for i := 0; i < len(testUserList_); i++ {
-			var ls CheckIsFollowLogic
-			isFollow := mysqlmanageserver.CheckIsFollowRequest{UserId: int64(testUserList_[i].Id), FollowerId: int64(in.LoginUserID)}
-			result, _ := ls.CheckIsFollow(&isFollow)
-			if result.Ok {
-				testUserList_[i].IsFollow = true
-			}
-		}
+	RedisDB, _ := redisconnect.RedisConnect()
+	userIDString := fmt.Sprintf("%s%s:%d", KVDBName, "user_id", in.UserID)
+	userIDList, _ := RedisDB.SMembers(l.ctx, userIDString).Result() // 找到关注列表的用户ID
+
+	for _, val := range userIDList {
+		var userInfo RelationUserInfo
+		_ = svc.DB.Table("user_info").Where("user_id = ?", val).Find(&userInfo).Error
+		followerIDString := fmt.Sprintf("%s%s:%d", KVDBName, "follower_id", userInfo.UserID)
+		userInfoFollowCountList, _ := RedisDB.SMembers(l.ctx, followerIDString).Result() // 找到关注的列表
+		userIDString := fmt.Sprintf("%s%s:%d", KVDBName, "user_id", userInfo.UserID)
+		userInfoFollowerCountList, _ := RedisDB.SMembers(l.ctx, userIDString).Result() // 找到粉丝的列表
+
+		isFollowRedis := RedisDB.SIsMember(l.ctx, followerIDString, in.UserID).Val() // redis查看关注列表中是否有这个人
+		testUserList_ = append(testUserList_, &mysqlmanageserver.RelationUser{
+			Id:            userInfo.UserID,
+			Name:          userInfo.UserNickName,
+			FollowCount:   int64(len(userInfoFollowCountList)),
+			FollowerCount: int64(len(userInfoFollowerCountList)),
+			IsFollow:      isFollowRedis,
+		})
 	}
+
 	return &mysqlmanageserver.RelationFollowListResponse{RelationUser: testUserList_}, nil
 }
+
+// func (l *RelationFollowListLogic) RelationFollowList(in *mysqlmanageserver.RelationFollowListRequest) (resp *mysqlmanageserver.RelationFollowListResponse, respErr error) {
+// 	// todo: add your logic here and delete this line
+
+// 	testUserList_ := make([]*mysqlmanageserver.RelationUser, 0)
+
+// 	db := svc.DB
+// 	//#查询某个账号关注的所有账号   follower_id：账号
+// 	userInfoList, err := db.Raw(fmt.Sprintf("SELECT * FROM user_info where user_id in(SELECT user_id FROM follow_and_follower_list where follower_id = %d)", in.UserID)).Rows()
+// 	if err != nil {
+// 		return &mysqlmanageserver.RelationFollowListResponse{}, err
+// 	} else {
+// 		for userInfoList.Next() {
+// 			tempUserList := mysqlmanageserver.RelationUser{}
+// 			userInfoList.Scan(&tempUserList.Id, &tempUserList.Name, &tempUserList.FollowCount, &tempUserList.FollowerCount, &tempUserList.IsFollow) //！！err :查询出来的列数不同、数据格式不同时会报错，不影响格式正确的变量
+// 			testUserList_ = append(testUserList_, &tempUserList)
+// 		}
+// 		//查询一遍上面查出来的id，是否已被当前登录的账号关注
+// 		for i := 0; i < len(testUserList_); i++ {
+// 			var ls CheckIsFollowLogic
+// 			isFollow := mysqlmanageserver.CheckIsFollowRequest{UserId: int64(testUserList_[i].Id), FollowerId: int64(in.LoginUserID)}
+// 			result, _ := ls.CheckIsFollow(&isFollow)
+// 			if result.Ok {
+// 				testUserList_[i].IsFollow = true
+// 			}
+// 		}
+// 	}
+// 	return &mysqlmanageserver.RelationFollowListResponse{RelationUser: testUserList_}, nil
+// }

--- a/oprations/redisconnect/mysqlconnect.go
+++ b/oprations/redisconnect/mysqlconnect.go
@@ -1,0 +1,24 @@
+package redisconnect
+
+import "github.com/go-redis/redis/v8"
+
+// 声明一个全局的redisDb变量
+// var RedisDB *redis.Client
+
+// 根据redis配置初始化一个客户端
+func RedisConnect() (RedisDB *redis.Client, err error) {
+	RedisDB = redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379", // redis地址
+		Password: "",               // redis密码，没有则留空
+		DB:       0,                // 默认数据库，默认是0
+	})
+
+	//通过 *redis.Client.Ping() 来检查是否成功连接到了redis服务器
+	// 但是语法报错
+	// _, err = RedisDB.Ping().Result()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	return RedisDB, nil
+}
+


### PR DESCRIPTION
数据库表follow_and_follower_list已弃用，用redis来保存
FollowAndFollowerList:follower_id:3 // 标识ID为3的用户的粉丝set
FollowAndFollowerList:user_id:3 // 标识ID为3的用户的关注set

影响的接口：
/douyin/relation/action
/douyin/relation/follow/list
/douyin/relation/follower/list

将来user_info中的follw_count和follower_count也可以删除，通过读取redis，set中的数量来确定